### PR TITLE
fix: TemplateExecutor fixed attributes

### DIFF
--- a/src/main/java/com/cefriel/template/Main.java
+++ b/src/main/java/com/cefriel/template/Main.java
@@ -204,29 +204,29 @@ public class Main {
 			rmlMap.put("basePath", basePath.toString() + "/");
 
 			Path compiledTemplatePath = Paths.get(basePath + "template.rml.vm");
-			TemplateExecutor templateExecutor = new TemplateExecutor(new RMLCompilerUtils(), false, false,
-					true, new TemplateMap(rmlMap), null);
-			templateExecutor.executeMapping(compilerReaderMap, rmlCompiler, compiledTemplatePath);
+			TemplateExecutor templateExecutor = new TemplateExecutor(false, false,
+					true, null);
+			templateExecutor.executeMapping(compilerReaderMap, rmlCompiler, compiledTemplatePath, new RMLCompilerUtils(), new TemplateMap(rmlMap));
 			templatePath = compiledTemplatePath;
 		}
 
 		try {
-			TemplateExecutor templateExecutor = new TemplateExecutor(templateFunctions, failInvalidRef, trimTemplate, templateInResources, templateMap, formatter);
+			TemplateExecutor templateExecutor = new TemplateExecutor(failInvalidRef, trimTemplate, templateInResources, formatter);
 			if(timePath != null)
 				try (FileWriter pw = new FileWriter(timePath.toFile(), true)) {
 					long start = Instant.now().toEpochMilli();
 					if(queryPath != null)
-						templateExecutor.executeMappingParametric(readerMap, templatePath, queryPath, destinationPath);
+						templateExecutor.executeMappingParametric(readerMap, templatePath, queryPath, destinationPath, templateFunctions, templateMap);
 					else
-						templateExecutor.executeMapping(readerMap, templatePath, destinationPath);
+						templateExecutor.executeMapping(readerMap, templatePath, destinationPath, templateFunctions, templateMap);
 					long duration = Instant.now().toEpochMilli() - start;
 					pw.write(templatePath + "," + destinationPath + "," + duration + "\n");
 				}
 			else{
 				if(queryPath != null)
-					templateExecutor.executeMappingParametric(readerMap, templatePath, queryPath, destinationPath);
+					templateExecutor.executeMappingParametric(readerMap, templatePath, queryPath, destinationPath, templateFunctions, templateMap);
 				else
-					templateExecutor.executeMapping(readerMap, templatePath, destinationPath);
+					templateExecutor.executeMapping(readerMap, templatePath, destinationPath, templateFunctions, templateMap);
 			}
 		} catch (Exception e) {
 			Files.deleteIfExists(destinationPath);

--- a/src/main/java/com/cefriel/template/TemplateExecutor.java
+++ b/src/main/java/com/cefriel/template/TemplateExecutor.java
@@ -50,6 +50,14 @@ public class TemplateExecutor {
         this.velocityEngine = Util.createVelocityEngine(this.templateInResourcesFolder, failInvalidRef);
     }
 
+    public String executeMapping(Map<String, Reader> readers, Path templatePath) throws Exception {
+        return executeMapping(readers, templatePath, null, null);
+    }
+
+    public Path executeMapping(Map<String, Reader> readers, Path templatePath, Path outputFile) throws Exception {
+        return executeMapping(readers, templatePath, outputFile,null, null);
+    }
+
     // methods called from cli
     public String executeMapping(Map<String, Reader> readers, Path templatePath, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
         Path usedTemplatePath = this.trimTemplate ? trimTemplate(templatePath) : templatePath;
@@ -61,6 +69,15 @@ public class TemplateExecutor {
         VelocityContext velocityContext = templateFunctions == null ? Util.createVelocityContext(readers, templateMap) : Util.createVelocityContext(readers, templateMap, templateFunctions);
         return applyTemplate(usedTemplatePath, outputFilePath, velocityContext);
     }
+
+    public Map<String, String> executeMappingParametric(Map<String, Reader> readers, Path templatePath, Path queryPath) throws Exception {
+        return executeMappingParametric(readers, templatePath, queryPath, null, null);
+    }
+
+    public List<Path> executeMappingParametric(Map<String, Reader> readers, Path templatePath, Path queryPath, Path outputFilePath) throws Exception {
+        return executeMappingParametric(readers, templatePath, queryPath, outputFilePath, null, null);
+    }
+
     public Map<String, String> executeMappingParametric(Map<String, Reader> readers, Path templatePath, Path queryPath, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
         Path usedTemplatePath = this.trimTemplate ? trimTemplate(templatePath) : templatePath;
         String query = Files.readString(queryPath);
@@ -140,14 +157,32 @@ public class TemplateExecutor {
 
     // STREAM OPTIONS
     // non-parametric return string result
+
+    public String executeMapping(Map<String, Reader> readers, InputStream template) throws Exception {
+        return executeMapping(readers, template, null, null);
+    }
+
+    public Path executeMapping(Map<String, Reader> readers, InputStream template, Path outputFile) throws Exception {
+        return executeMapping(readers, template, outputFile,null, null);
+    }
+
     public String executeMapping(Map<String, Reader> readers, InputStream template, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
         VelocityContext velocityContext = templateFunctions == null ? Util.createVelocityContext(readers, templateMap) : Util.createVelocityContext(readers, templateMap, templateFunctions);
         return applyTemplate(template, velocityContext);
     }
-    public Path executeMapping(Map<String, Reader> readers, InputStream template, Path outputFilePath, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
+    public Path executeMapping(Map<String, Reader> readers, InputStream template, Path outputFile, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
         VelocityContext velocityContext = templateFunctions == null ? Util.createVelocityContext(readers, templateMap) : Util.createVelocityContext(readers, templateMap, templateFunctions);
-        return applyTemplate(template, outputFilePath, velocityContext);
+        return applyTemplate(template, outputFile, velocityContext);
     }
+
+    public Map<String, String> executeMappingParametric(Map<String, Reader> readers, InputStream template, InputStream query) throws Exception {
+        return executeMappingParametric(readers, template, query, null, null);
+    }
+
+    public List<Path> executeMappingParametric(Map<String, Reader> readers, InputStream template, InputStream query, Path outputFilePath) throws Exception {
+        return executeMappingParametric(readers, template, query, outputFilePath, null, null);
+    }
+
     public Map<String, String> executeMappingParametric(Map<String, Reader> readers, InputStream template, InputStream query, TemplateFunctions templateFunctions, TemplateMap templateMap) throws Exception {
         String queryString = Util.inputStreamToString(query);
         VelocityContext velocityContext = templateFunctions == null ? Util.createVelocityContext(readers, templateMap) : Util.createVelocityContext(readers, templateMap, templateFunctions);

--- a/src/test/java/com/cefriel/template/JsonReaderTest.java
+++ b/src/test/java/com/cefriel/template/JsonReaderTest.java
@@ -34,7 +34,7 @@ public class JsonReaderTest {
         TemplateExecutor executor = new TemplateExecutor(true, false, false,null);
         Path template = Paths.get("src/test/resources/json/template.vm");
 
-        String result = executor.executeMapping(Map.of("reader",reader), template, new TemplateFunctions(), null);
+        String result = executor.executeMapping(Map.of("reader",reader), template);
         String expectedOutput = Files.readString(Paths.get("src/test/resources/json/correct-output.ttl"));
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");

--- a/src/test/java/com/cefriel/template/JsonReaderTest.java
+++ b/src/test/java/com/cefriel/template/JsonReaderTest.java
@@ -31,10 +31,10 @@ public class JsonReaderTest {
     @Test
     public void jsonTest() throws Exception {
         JSONReader reader = new JSONReader(new File("src/test/resources/json/example.json"));
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), true, false, false,null ,null);
+        TemplateExecutor executor = new TemplateExecutor(true, false, false,null);
         Path template = Paths.get("src/test/resources/json/template.vm");
 
-        String result = executor.executeMapping(Map.of("reader",reader), template);
+        String result = executor.executeMapping(Map.of("reader",reader), template, new TemplateFunctions(), null);
         String expectedOutput = Files.readString(Paths.get("src/test/resources/json/correct-output.ttl"));
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");

--- a/src/test/java/com/cefriel/template/MultipleReadersTest.java
+++ b/src/test/java/com/cefriel/template/MultipleReadersTest.java
@@ -17,8 +17,8 @@ public class MultipleReadersTest {
         Map<String, Reader> readers = Map.of("reader1", new CSVReader(new File("src/test/resources/multiple-readers/a.csv")),
                 "reader2", new CSVReader(new File("src/test/resources/multiple-readers/b.csv")));
         Path template = Paths.get("src/test/resources/multiple-readers/template.vm");
-        TemplateExecutor templateExecutor = new TemplateExecutor(new TemplateFunctions(), true, false, false, null, null);
-        String result = templateExecutor.executeMapping(readers, template).replaceAll("\\r\\n", "\n");;
+        TemplateExecutor templateExecutor = new TemplateExecutor( true, false, false, null);
+        String result = templateExecutor.executeMapping(readers, template, new TemplateFunctions(), null).replaceAll("\\r\\n", "\n");;
         String expectedOutput = "1,2,3,4,5,6".replaceAll("\\r\\n", "\n");
         assert expectedOutput.equals(result);
     }

--- a/src/test/java/com/cefriel/template/MultipleReadersTest.java
+++ b/src/test/java/com/cefriel/template/MultipleReadersTest.java
@@ -18,7 +18,7 @@ public class MultipleReadersTest {
                 "reader2", new CSVReader(new File("src/test/resources/multiple-readers/b.csv")));
         Path template = Paths.get("src/test/resources/multiple-readers/template.vm");
         TemplateExecutor templateExecutor = new TemplateExecutor( true, false, false, null);
-        String result = templateExecutor.executeMapping(readers, template, new TemplateFunctions(), null).replaceAll("\\r\\n", "\n");;
+        String result = templateExecutor.executeMapping(readers, template).replaceAll("\\r\\n", "\n");;
         String expectedOutput = "1,2,3,4,5,6".replaceAll("\\r\\n", "\n");
         assert expectedOutput.equals(result);
     }

--- a/src/test/java/com/cefriel/template/NullAndMissingFieldsTest.java
+++ b/src/test/java/com/cefriel/template/NullAndMissingFieldsTest.java
@@ -33,7 +33,7 @@ public class NullAndMissingFieldsTest {
         Path template = Paths.get("src/test/resources/null-and-missing-fields/template.vm");
 
         TemplateExecutor executor = new TemplateExecutor( false, false, false,  null);
-        String result = executor.executeMapping(Map.of("reader", jsonReader), template, new TemplateFunctions(), null);
+        String result = executor.executeMapping(Map.of("reader", jsonReader), template);
         String expectedOutput = Files.readString(Paths.get("src/test/resources/null-and-missing-fields/correct-output.txt"));
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");

--- a/src/test/java/com/cefriel/template/NullAndMissingFieldsTest.java
+++ b/src/test/java/com/cefriel/template/NullAndMissingFieldsTest.java
@@ -32,8 +32,8 @@ public class NullAndMissingFieldsTest {
         JSONReader jsonReader = new JSONReader(new File("src/test/resources/null-and-missing-fields/modified.json"));
         Path template = Paths.get("src/test/resources/null-and-missing-fields/template.vm");
 
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), false, false, false, null, null);
-        String result = executor.executeMapping(Map.of("reader", jsonReader), template);
+        TemplateExecutor executor = new TemplateExecutor( false, false, false,  null);
+        String result = executor.executeMapping(Map.of("reader", jsonReader), template, new TemplateFunctions(), null);
         String expectedOutput = Files.readString(Paths.get("src/test/resources/null-and-missing-fields/correct-output.txt"));
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");

--- a/src/test/java/com/cefriel/template/RDFReaderTests.java
+++ b/src/test/java/com/cefriel/template/RDFReaderTests.java
@@ -67,7 +67,7 @@ public class RDFReaderTests {
         Path template = Paths.get(resolvePath(folder, "template.vm"));
 
         String expectedOutput = Files.readString(Paths.get(resolvePath(folder, "agency.csv")));
-        String result = executor.executeMapping(Map.of("reader", reader), template, new TemplateFunctions(), null);
+        String result = executor.executeMapping(Map.of("reader", reader), template);
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");
         result = result.replaceAll("\\r\\n", "\n");
@@ -84,7 +84,7 @@ public class RDFReaderTests {
         Path template = Paths.get(resolvePath(folder, "template.vm"));
 
         Path queryPath = Paths.get(resolvePath(folder, "query.txt"));
-        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, queryPath, new TemplateFunctions(), null);
+        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, queryPath);
 
         for(String id : output.keySet()) {
             String expectedOutput = Files
@@ -105,7 +105,7 @@ public class RDFReaderTests {
         InputStream template = new FileInputStream(Paths.get(resolvePath(folder, "template.vm")).toString());
         InputStream query = new FileInputStream(Paths.get(resolvePath(folder, "query.txt")).toString());
         TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
-        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, query, new TemplateFunctions(), null);
+        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, query);
 
         for(String id : output.keySet()) {
             String expectedOutput = Files

--- a/src/test/java/com/cefriel/template/RDFReaderTests.java
+++ b/src/test/java/com/cefriel/template/RDFReaderTests.java
@@ -43,10 +43,10 @@ public class RDFReaderTests {
 
         String folder = "agency";
         reader.addFile(resolvePath(folder, "input.ttl"), RDFFormat.TURTLE);
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), true, false, false, null, null);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
         Path template = Paths.get(resolvePath(folder, "template.vm"));
         String expectedOutput = Files.readString(Paths.get(resolvePath(folder, "agency.csv")));
-        String result = executor.executeMapping(Map.of("reader", reader), template);
+        String result = executor.executeMapping(Map.of("reader", reader), template, new TemplateFunctions(), null);
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");
         result = result.replaceAll("\\r\\n", "\n");
 
@@ -63,11 +63,11 @@ public class RDFReaderTests {
         reader.setBaseIRI(baseIri);
         reader.addFile(resolvePath(folder, "input.ttl"), RDFFormat.TURTLE);
         reader.addFile(resolvePath(folder, "input2.ttl"), RDFFormat.TURTLE);
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), true, false, false, null, null);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
         Path template = Paths.get(resolvePath(folder, "template.vm"));
 
         String expectedOutput = Files.readString(Paths.get(resolvePath(folder, "agency.csv")));
-        String result = executor.executeMapping(Map.of("reader", reader), template);
+        String result = executor.executeMapping(Map.of("reader", reader), template, new TemplateFunctions(), null);
 
         expectedOutput = expectedOutput.replaceAll("\\r\\n", "\n");
         result = result.replaceAll("\\r\\n", "\n");
@@ -80,11 +80,11 @@ public class RDFReaderTests {
         reader.setBaseIRI("http://www.cefriel.com/data/");
         String folder = "agency-parametric";
         reader.addFile(resolvePath(folder, "input.ttl"), RDFFormat.TURTLE);
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), true, false, false, null, null);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
         Path template = Paths.get(resolvePath(folder, "template.vm"));
 
         Path queryPath = Paths.get(resolvePath(folder, "query.txt"));
-        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, queryPath);
+        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, queryPath, new TemplateFunctions(), null);
 
         for(String id : output.keySet()) {
             String expectedOutput = Files
@@ -104,8 +104,8 @@ public class RDFReaderTests {
         reader.addFile(resolvePath(folder, "input.ttl"), RDFFormat.TURTLE);
         InputStream template = new FileInputStream(Paths.get(resolvePath(folder, "template.vm")).toString());
         InputStream query = new FileInputStream(Paths.get(resolvePath(folder, "query.txt")).toString());
-        TemplateExecutor executor = new TemplateExecutor(new TemplateFunctions(), true, false, false, null, null);
-        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, query);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
+        Map<String, String> output = executor.executeMappingParametric(Map.of("reader", reader), template, query, new TemplateFunctions(), null);
 
         for(String id : output.keySet()) {
             String expectedOutput = Files

--- a/src/test/java/com/cefriel/template/RMLTests.java
+++ b/src/test/java/com/cefriel/template/RMLTests.java
@@ -72,7 +72,7 @@ public class RMLTests {
         TemplateExecutor rmlTemplateExecutor = new TemplateExecutor(false, false, true, null);
         TemplateExecutor templateExecutor = new TemplateExecutor(false, false, false, null);
         rmlTemplateExecutor.executeMapping(Map.of("reader", compilerReader), rmlCompiler, compiledTemplatePath, new RMLCompilerUtils(), new TemplateMap(rmlMap));
-        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), compiledTemplatePath, new TemplateFunctions(), null);
+        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), compiledTemplatePath);
         Files.delete(compiledTemplatePath);
 
         Model resultModel = parseRDFString(result);

--- a/src/test/java/com/cefriel/template/RMLTests.java
+++ b/src/test/java/com/cefriel/template/RMLTests.java
@@ -69,10 +69,10 @@ public class RMLTests {
         Map<String,String> rmlMap = new HashMap<>();
         rmlMap.put("basePath", FOLDER);
 
-        TemplateExecutor rmlTemplateExecutor = new TemplateExecutor(new RMLCompilerUtils(), false, false, true, new TemplateMap(rmlMap), null);
-        TemplateExecutor templateExecutor = new TemplateExecutor(new TemplateFunctions(), false, false, false, null, null);
-        rmlTemplateExecutor.executeMapping(Map.of("reader", compilerReader), rmlCompiler, compiledTemplatePath);
-        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), compiledTemplatePath);
+        TemplateExecutor rmlTemplateExecutor = new TemplateExecutor(false, false, true, null);
+        TemplateExecutor templateExecutor = new TemplateExecutor(false, false, false, null);
+        rmlTemplateExecutor.executeMapping(Map.of("reader", compilerReader), rmlCompiler, compiledTemplatePath, new RMLCompilerUtils(), new TemplateMap(rmlMap));
+        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), compiledTemplatePath, new TemplateFunctions(), null);
         Files.delete(compiledTemplatePath);
 
         Model resultModel = parseRDFString(result);

--- a/src/test/java/com/cefriel/template/TemplateFunctionsTest.java
+++ b/src/test/java/com/cefriel/template/TemplateFunctionsTest.java
@@ -92,7 +92,7 @@ public class TemplateFunctionsTest {
 
         CustomTemplateFunctions customTemplateFunctions = new CustomTemplateFunctions();
         Map<String, Reader> readerMap = new HashMap<>();
-        readerMap.put("reader", (Reader) null);
+        readerMap.put("reader", null);
         TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
         String result = executor.executeMapping(readerMap, fileInputStream, customTemplateFunctions, null);
 

--- a/src/test/java/com/cefriel/template/TemplateFunctionsTest.java
+++ b/src/test/java/com/cefriel/template/TemplateFunctionsTest.java
@@ -77,10 +77,10 @@ public class TemplateFunctionsTest {
 
         Path template = Paths.get("src/test/resources/custom-functions/template.vm");
         CustomTemplateFunctions customTemplateFunctions = new CustomTemplateFunctions();
-        TemplateExecutor executor = new TemplateExecutor(customTemplateFunctions, true, false, false, null, null);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
         Map<String, Reader> readerMap = new HashMap<>();
         readerMap.put("reader", (Reader) null);
-        String result = executor.executeMapping(readerMap, template);
+        String result = executor.executeMapping(readerMap, template, customTemplateFunctions, null);
         Assertions.assertEquals(result, customTemplateFunctions.printMessage());
     }
 
@@ -93,8 +93,8 @@ public class TemplateFunctionsTest {
         CustomTemplateFunctions customTemplateFunctions = new CustomTemplateFunctions();
         Map<String, Reader> readerMap = new HashMap<>();
         readerMap.put("reader", (Reader) null);
-        TemplateExecutor executor = new TemplateExecutor(customTemplateFunctions, true, false, false, null, null);
-        String result = executor.executeMapping(readerMap, fileInputStream);
+        TemplateExecutor executor = new TemplateExecutor( true, false, false, null);
+        String result = executor.executeMapping(readerMap, fileInputStream, customTemplateFunctions, null);
 
         Assertions.assertEquals(result, customTemplateFunctions.printMessage());
     }


### PR DESCRIPTION
TemplateFunctions and TemplateMap should be provided for each mapping execution, as they could be changed (TemplateMap) or could contain stateful logic (TemplateFunctions). 

Closes #35, #36.