### PR TITLE
Helper methods for RML to MTL conversion

### DIFF
--- a/src/main/java/com/cefriel/template/Main.java
+++ b/src/main/java/com/cefriel/template/Main.java
@@ -29,6 +29,7 @@ import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -181,7 +182,10 @@ public class Main {
 			}
 		}
 		if(compileRML) {
-			Util.validateRML(templatePath, verbose);
+			try (InputStream rmlMappingStream = Files.newInputStream(templatePath))
+			{
+				Util.validateRML(rmlMappingStream, verbose);
+			}
 
 			Reader compilerReader = TemplateFunctions.getRDFReaderFromFile(templatePath.toString());
 			Map<String, Reader> compilerReaderMap = new HashMap<>();

--- a/src/main/java/com/cefriel/template/utils/RMLCompilerUtils.java
+++ b/src/main/java/com/cefriel/template/utils/RMLCompilerUtils.java
@@ -209,6 +209,17 @@ public class RMLCompilerUtils extends TemplateFunctions {
         return false;                     
     }
 
+    public String getBaseIRI(String turtle) {
+        Pattern p = Pattern.compile("@base <([^<>]*)>");
+        Matcher m = p.matcher(turtle);
+
+        if (m.find()) {
+            return m.group(1);
+        } else {
+            return null;
+        }
+    }
+
     /**
      * From rmlmapper <a href="https://github.com/RMLio/rmlmapper-java/blob/6492743f9c81523b6e9142c929d3aaecc78d67eb/src/main/java/be/ugent/rml/Utils.java#L634">...</a>
      *
@@ -223,15 +234,7 @@ public class RMLCompilerUtils extends TemplateFunctions {
         } catch (IOException e) {
             turtle = "";
         }
-
-        Pattern p = Pattern.compile("@base <([^<>]*)>");
-        Matcher m = p.matcher(turtle);
-
-        if (m.find()) {
-            return m.group(1);
-        } else {
-            return null;
-        }
+        return getBaseIRI(turtle);
     }
 
 }

--- a/src/main/java/com/cefriel/template/utils/Util.java
+++ b/src/main/java/com/cefriel/template/utils/Util.java
@@ -31,6 +31,7 @@ import com.cefriel.template.io.xml.XMLReader;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.apache.velocity.runtime.resource.loader.FileResourceLoader;
 import org.apache.velocity.tools.generic.*;
 import org.eclipse.rdf4j.common.exception.ValidationException;
 import org.eclipse.rdf4j.model.Model;
@@ -198,6 +199,10 @@ public class Util {
             velocityEngine.setProperty("resource.loaders", "class");
             velocityEngine.setProperty("resource.loader.class.class",
                     ClasspathResourceLoader.class.getName());
+        } else{
+            velocityEngine.setProperty("resource.loaders", "file");
+            velocityEngine.setProperty("resource.loader.file.class", FileResourceLoader.class.getName());
+            velocityEngine.setProperty("resource.loader.file.path", "");
         }
         velocityEngine.init();
         return velocityEngine;

--- a/src/test/java/com/cefriel/template/RMLTests.java
+++ b/src/test/java/com/cefriel/template/RMLTests.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,51 +41,49 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RMLTests {
 
-    final static String FOLDER = "src/test/resources/rml/";
-    private String resolvePath(String folder, String file) {
-        return FOLDER + file;
-    }
+    final static Path FOLDER = Path.of("src/test/resources/rml/");
 
     @Test
     public void invalidRMLTest() throws Exception {
-        String folder = "rml";
-        Path rmlMappings = Paths.get(resolvePath(folder, "invalid-mapping.ttl"));
-        assertThrows(RuntimeException.class, () -> Util.validateRML(rmlMappings, false));
+        Path rmlMappings = FOLDER.resolve(Path.of("invalid-mapping.ttl"));
+        try (InputStream rmlMapping = Files.newInputStream(rmlMappings)) {
+            assertThrows(RuntimeException.class,
+                    () -> Util.validateRML(rmlMapping, false));
+        }
     }
 
     @Test
     public void validRMLTest() throws Exception {
-        String folder = "rml";
-        String rmlMappings = resolvePath(folder, "mapping.ttl");
+        Path rmlMapping = FOLDER.resolve(Path.of("mapping.ttl"));
+        String expectedOutput = Files.readString(FOLDER.resolve("output.nq"));
 
-        String expectedOutput = Files.readString(Paths.get(resolvePath(folder, "output.nq")));
+        try (InputStream rmlMappingStream = Files.newInputStream(rmlMapping)) {
+            Util.validateRML(rmlMappingStream, false);
+        }
 
-        Util.validateRML(Paths.get(rmlMappings), false);
-
-        Reader compilerReader = TemplateFunctions.getRDFReaderFromFile(rmlMappings);
+        Reader compilerReader = TemplateFunctions.getRDFReaderFromFile(rmlMapping.toString());
 
         Map<String,String> rmlMap = new HashMap<>();
         rmlMap.put("basePath", null);
 
-
         TemplateExecutor templateExecutor = new TemplateExecutor(false, false, false, null);
-        Path mappingMTL = Util.compiledMTLMapping(Path.of(rmlMappings), null, Path.of(FOLDER), false, false);
-        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), mappingMTL);
-        Files.delete(mappingMTL);
+        try (InputStream rmlMappingStream = Files.newInputStream(rmlMapping)) {
+            Path mappingMTL = Util.compiledMTLMapping(rmlMappingStream, null, FOLDER, false, false);
+            String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), FOLDER.resolve(mappingMTL.getFileName()));
+            Files.delete(mappingMTL);
 
-        Model resultModel = parseRDFString(result);
-        Model expectedOutputModel = parseRDFString(expectedOutput);
+            Model resultModel = parseRDFString(result);
+            Model expectedOutputModel = parseRDFString(expectedOutput);
 
-        assert(Models.isomorphic(resultModel, expectedOutputModel));
+            assert(Models.isomorphic(resultModel, expectedOutputModel));
+        }
     }
 
     private static Model parseRDFString(String rdfString) throws Exception {
         RDFParser rdfParser = Rio.createParser(RDFFormat.NQUADS);
-
         Model model = new TreeModel();
         rdfParser.setRDFHandler(new StatementCollector(model));
         rdfParser.parse(new StringReader(rdfString), "http://example.com/base/");
         return model;
     }
-
 }

--- a/src/test/java/com/cefriel/template/RMLTests.java
+++ b/src/test/java/com/cefriel/template/RMLTests.java
@@ -54,7 +54,6 @@ public class RMLTests {
 
     @Test
     public void validRMLTest() throws Exception {
-
         String folder = "rml";
         String rmlMappings = resolvePath(folder, "mapping.ttl");
 
@@ -63,17 +62,15 @@ public class RMLTests {
         Util.validateRML(Paths.get(rmlMappings), false);
 
         Reader compilerReader = TemplateFunctions.getRDFReaderFromFile(rmlMappings);
-        Path rmlCompiler = Paths.get("rml/rml-compiler.vm");
-        Path compiledTemplatePath = Paths.get(resolvePath(folder,"template.rml.vm"));
 
         Map<String,String> rmlMap = new HashMap<>();
-        rmlMap.put("basePath", FOLDER);
+        rmlMap.put("basePath", null);
 
-        TemplateExecutor rmlTemplateExecutor = new TemplateExecutor(false, false, true, null);
+
         TemplateExecutor templateExecutor = new TemplateExecutor(false, false, false, null);
-        rmlTemplateExecutor.executeMapping(Map.of("reader", compilerReader), rmlCompiler, compiledTemplatePath, new RMLCompilerUtils(), new TemplateMap(rmlMap));
-        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), compiledTemplatePath);
-        Files.delete(compiledTemplatePath);
+        Path mappingMTL = Util.compiledMTLMapping(Path.of(rmlMappings), null, Path.of(FOLDER), false, false);
+        String result = templateExecutor.executeMapping(Map.of("reader", compilerReader), mappingMTL);
+        Files.delete(mappingMTL);
 
         Model resultModel = parseRDFString(result);
         Model expectedOutputModel = parseRDFString(expectedOutput);


### PR DESCRIPTION
- Introduces a helper method to handle the conversion logic from an RML mapping to an MTL template. This enables code reuse across both the mapping-template and Chimera components.

- Updates the root path of the FileResourceLoader from the default "./" to an empty string (""). As a result, paths provided to Velocity no longer need to be relative to "./". However, it remains possible to specify paths relative to the basePath CLI parameter, or to use absolute paths directly. Internally, VTL always resolves paths to absolute locations ([ref](https://github.com/apache/velocity-engine/blob/df1b7f2aebb5c97ece7b20134644370e9e4938b8/velocity-engine-core/src/main/java/org/apache/velocity/runtime/resource/loader/FileResourceLoader.java#L201-L207)).        
